### PR TITLE
Make sure that we have the streams before closing them.

### DIFF
--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
@@ -218,7 +218,7 @@ public class DownloadDispatcher extends Thread {
 
         } finally {
         	try {
-        		in.close();
+        		if (in != null) in.close();
         	} catch (IOException e) {
         		e.printStackTrace();
         	}
@@ -229,7 +229,7 @@ public class DownloadDispatcher extends Thread {
             } catch (IOException e) {
             } finally {
             	try {
-            		out.close();
+            		if (out != null) out.close();
             	} catch (IOException e) {
             		e.printStackTrace();
             	}


### PR DESCRIPTION
If the streams cannot be created we'll have only null references to close(). This change makes sure that the streams are available before closing them.