### PR TITLE
Allow Providing Callback Handler

### DIFF
--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequestQueue.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequestQueue.java
@@ -92,9 +92,7 @@ public class DownloadRequestQueue {
 	 * Default constructor.
 	 */
 	public DownloadRequestQueue() {
-		int processors = Runtime.getRuntime().availableProcessors();
-		mDownloadDispatchers = new DownloadDispatcher[processors];
-		mDelivery = new CallBackDelivery(new Handler(Looper.getMainLooper()));
+		doConstruct(new Handler(Looper.getMainLooper()));
 	}
 
 	/**
@@ -103,9 +101,20 @@ public class DownloadRequestQueue {
 	 * Deprecated:
 	 */
 	public DownloadRequestQueue(int threadPoolSize) {
-		mDelivery = new CallBackDelivery(new Handler(Looper.getMainLooper()));
-		int processors = Runtime.getRuntime().availableProcessors();
-		mDownloadDispatchers = new DownloadDispatcher[processors];
+		doConstruct(new Handler(Looper.getMainLooper()));
+	}
+
+	/**
+	 * Construct with provided callback handler.
+	 *
+	 * @param callbackHandler
+	 */
+	public DownloadRequestQueue(Handler callbackHandler) {
+		if(callbackHandler == null) {
+			callbackHandler = new Handler(Looper.getMainLooper());
+		}
+
+		doConstruct(callbackHandler);
 	}
 
 	public void start() {
@@ -122,7 +131,7 @@ public class DownloadRequestQueue {
 	// Package-Private methods.
 	/**
 	 * Generates a download id for the request and adds the download request to the download request queue for the dispatchers pool to act on immediately.
-	 * 
+	 *
 	 * @param request
 	 * @return downloadId
 	 */
@@ -144,7 +153,7 @@ public class DownloadRequestQueue {
 
 	/**
 	 * Returns the current download state for a download request.
-	 * 
+	 *
 	 * @param downloadId
 	 * @return
 	 */
@@ -176,7 +185,7 @@ public class DownloadRequestQueue {
 
 	/**
 	 * Cancel a particular download in progress. Returns 1 if the download Id is found else returns 0.
-	 * 
+	 *
 	 * @param downloadId
 	 * @return int
 	 */
@@ -219,7 +228,7 @@ public class DownloadRequestQueue {
 
 		if (mDownloadDispatchers != null) {
 			stop();
-			
+
 			for (int i = 0; i < mDownloadDispatchers.length; i++) {
 				mDownloadDispatchers[i] = null;
 			}
@@ -229,6 +238,17 @@ public class DownloadRequestQueue {
 	}
 
 	// Private methods.
+
+	/**
+	 * Perform construction.
+	 *
+	 * @param callbackHandler
+	 */
+	private void doConstruct(Handler callbackHandler) {
+		int processors = Runtime.getRuntime().availableProcessors();
+		mDownloadDispatchers = new DownloadDispatcher[processors];
+		mDelivery = new CallBackDelivery(callbackHandler);
+	}
 
 	/**
 	 * Stops download dispatchers.

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequestQueue.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequestQueue.java
@@ -3,6 +3,7 @@ package com.thin.downloadmanager;
 import android.os.Handler;
 import android.os.Looper;
 
+import java.security.InvalidParameterException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -92,7 +93,7 @@ public class DownloadRequestQueue {
 	 * Default constructor.
 	 */
 	public DownloadRequestQueue() {
-		doConstruct(new Handler(Looper.getMainLooper()));
+		initialize(new Handler(Looper.getMainLooper()));
 	}
 
 	/**
@@ -101,7 +102,7 @@ public class DownloadRequestQueue {
 	 * Deprecated:
 	 */
 	public DownloadRequestQueue(int threadPoolSize) {
-		doConstruct(new Handler(Looper.getMainLooper()));
+		initialize(new Handler(Looper.getMainLooper()));
 	}
 
 	/**
@@ -109,12 +110,12 @@ public class DownloadRequestQueue {
 	 *
 	 * @param callbackHandler
 	 */
-	public DownloadRequestQueue(Handler callbackHandler) {
-		if(callbackHandler == null) {
-			callbackHandler = new Handler(Looper.getMainLooper());
+	public DownloadRequestQueue(Handler callbackHandler) throws InvalidParameterException {
+		if (callbackHandler == null) {
+			throw new InvalidParameterException("callbackHandler must not be null");
 		}
 
-		doConstruct(callbackHandler);
+		initialize(callbackHandler);
 	}
 
 	public void start() {
@@ -244,7 +245,7 @@ public class DownloadRequestQueue {
 	 *
 	 * @param callbackHandler
 	 */
-	private void doConstruct(Handler callbackHandler) {
+	private void initialize(Handler callbackHandler) {
 		int processors = Runtime.getRuntime().availableProcessors();
 		mDownloadDispatchers = new DownloadDispatcher[processors];
 		mDelivery = new CallBackDelivery(callbackHandler);

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/ThinDownloadManager.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/ThinDownloadManager.java
@@ -2,6 +2,8 @@ package com.thin.downloadmanager;
 
 import android.os.Handler;
 
+import java.security.InvalidParameterException;
+
 public class ThinDownloadManager implements DownloadManager {
 
     /** Download request queue takes care of handling the request based on priority. */
@@ -20,7 +22,7 @@ public class ThinDownloadManager implements DownloadManager {
      *
      * @param callbackHandler
      */
-    public ThinDownloadManager(Handler callbackHandler) {
+    public ThinDownloadManager(Handler callbackHandler) throws InvalidParameterException {
         mRequestQueue = new DownloadRequestQueue(callbackHandler);
         mRequestQueue.start();
     }

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/ThinDownloadManager.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/ThinDownloadManager.java
@@ -1,5 +1,7 @@
 package com.thin.downloadmanager;
 
+import android.os.Handler;
+
 public class ThinDownloadManager implements DownloadManager {
 
     /** Download request queue takes care of handling the request based on priority. */
@@ -10,6 +12,16 @@ public class ThinDownloadManager implements DownloadManager {
     */
     public ThinDownloadManager() {
         mRequestQueue = new DownloadRequestQueue();
+        mRequestQueue.start();
+    }
+
+    /**
+     * Construct with provided callback handler
+     *
+     * @param callbackHandler
+     */
+    public ThinDownloadManager(Handler callbackHandler) {
+        mRequestQueue = new DownloadRequestQueue(callbackHandler);
         mRequestQueue.start();
     }
 


### PR DESCRIPTION
Added a constructor to ThinDownloadManager which takes a Handler for status callbacks. This allows the user to control which thread callbacks are Handled on.