### PR TITLE
Bug-Fix: Skip transferData() on createNewFile exception

### DIFF
--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
@@ -216,6 +216,7 @@ public class DownloadDispatcher extends Thread {
                     errorOccurred = true;
                     updateDownloadFailed(DownloadManager.ERROR_FILE_ERROR,
                         "Error in creating destination file");
+                    return; // escape to finally to skip transferData()
                 }
             }
 


### PR DESCRIPTION
Skip transferData() when destinationFile.createNewFile() throws IOException. This avoids a NullPointerException on transferData(). 

updateDownloadFailed() is still respected.