### PR TITLE
Optional delete on failure

### DIFF
--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
@@ -393,7 +393,7 @@ public class DownloadDispatcher extends Thread {
     public void updateDownloadFailed(int errorCode, String errorMsg) {
         shouldAllowRedirects = false;
         mRequest.setDownloadState(DownloadManager.STATUS_FAILED);
-        cleanupDestination();
+        if(mRequest.getDeleteOnFailure()) cleanupDestination();
         mDelivery.postDownloadFailed(mRequest, errorCode, errorMsg);
         mRequest.finish();
     }

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequest.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequest.java
@@ -48,6 +48,8 @@ public class DownloadRequest implements Comparable<DownloadRequest> {
      */
     private boolean mCanceled = false;
 
+    private boolean mDeleteOnFailure = true;
+
     private DownloadRequestQueue mRequestQueue;
 
     private DownloadStatusListener mDownloadListener;
@@ -203,6 +205,17 @@ public class DownloadRequest implements Comparable<DownloadRequest> {
     public DownloadRequest setDestinationURI(Uri destinationURI) {
         this.mDestinationURI = destinationURI;
         return this;
+    }
+
+    public boolean getDeleteOnFailure() {
+        return mDeleteOnFailure;
+    }
+
+    /**
+     * Set if file should be deleted on download failure. Use is optional: default is to delete.
+     */
+    public void setDeleteOnFailure(boolean deleteOnFailure) {
+        mDeleteOnFailure = deleteOnFailure;
     }
 
     /**


### PR DESCRIPTION
Add the option to keep downloaded data on failure. An optional setter is used to maintain API backward compatibility. A default value is used to maintain behavior backward compatibility.