### PR TITLE
Feature/wifi only downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Thin DownloadManager is an android library primary to download files and to avoi
   Most of the times we download using Android's DownloadManager to external files directory and upon successful completion move the downloaded file to the sandboxed application's cache/file directory to avoid writing a own download manager which is a bit tedious. This library is handy in such situations.
 
   * **No additional permissions required.** Any download initiated by your application using android DownloadManager would throw a progress notification on status bar letting user know that you are downloading a file. So you end up using *setVisibleInDownloadsUi(false)* & having this permission *android.permission.DOWNLOAD_WITHOUT_NOTIFICATION*. When users install your app, they would be shown this permission and it makes them scary not to install your app because you are downloading some files without user's notification. Why give a chance of user not installing your app for this permission. You definetly need this library in this case.
+    -Additional permissions may be required if downloading to external storage or using the WiFi-only DownloadRequest feature.
 
   * **Volley** - Google recommended Networking library for android doesn't have options to download a file.
 
@@ -52,8 +53,10 @@ Thin DownloadManager is an android library primary to download files and to avoi
   * Download URI, Destination URI.
   * Set Priority for request as HIGH or MEDIUM or LOW.
   * Takes Callback listener DownloadStatusListener
-  * Use custom Http Headers for a download request
-  * You can set a Retry Policy
+  * You can use custom Http Headers.
+  * You can set a Retry Policy.
+  * You can set to keep the destination file on download failure.
+  * You can set to only download over WiFi: If WiFi is unavailable, WiFi-only downloads are queued. When Wifi connects, WiFi-only downloads are started. If WiFi is disabled, it is up to the consuming app or user to enable WiFi. Using this requires additional permissions: see permissions section below.
 
      ``` java
         Uri downloadUri = Uri.parse("http://tcrn.ch/Yu1Ooo1");
@@ -84,6 +87,7 @@ Thin DownloadManager is an android library primary to download files and to avoi
 
 ####**ThinDownloadManager**
   * The number of threads used to perform parallel download is determined by the available processors on the device. Uses `Runtime.getRuntime().availableProcessors()` api.
+  * You can construct with a Handler to use for download status callbacks.
   
   	``` java
     private ThinDownloadManager downloadManager;
@@ -131,13 +135,14 @@ Thin DownloadManager is an android library primary to download files and to avoi
 
 ##No Permissions Required
   * Unless if you specify download destination to be in external public SDCard location.You might need *android.permission.WRITE_EXTERNAL_STORAGE* permission.
+  * Using WiFi-only downloads requires: ACCESS_NETWORK_STATE, CHANGE_NETWORK_STATE, ACCESS_WIFI_STATE, and WAKE_LOCK.
 
 ##Setup
 Include below line your build.gradle:
 
 ```java
 dependencies {
-    compile 'com.mani:ThinDownloadManager:1.2.4'
+    compile 'com.mani:ThinDownloadManager:1.3.0'
 }
 ```
 Make sure you included jcenter() in your repositories section.

--- a/ThinDownloadManager/build.gradle
+++ b/ThinDownloadManager/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
-version = "1.2.4"
+version = "1.3.0"
 group = "com.mani"
 
 def siteUrl = 'https://github.com/smanikandan14/ThinDownloadManager.git'
@@ -49,6 +49,18 @@ bintray {
     }
 }
 
+task deleteJar(type: Delete) {
+    delete 'libs/thindldman.jar'
+}
+
+task createJar(type: Copy) {
+    from('build/intermediates/bundles/debug/')
+    into('libs/')
+    include('classes.jar')
+    rename('classes.jar', 'thindldman.jar')
+}
+
+createJar.dependsOn(deleteJar, assembleDebug)
 
 install {
     repositories.mavenInstaller {

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadManager.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadManager.java
@@ -70,6 +70,11 @@ public interface DownloadManager {
 	public final static int ERROR_DOWNLOAD_SIZE_UNKNOWN = 1006;
 
 	/**
+	 * Error code when WiFi network becomes unavailable while creating connection
+	 */
+	public final static int ERROR_WIFI_UNAVAILABLE = 1007;
+
+	/**
 	 * Error code when passed URI is malformed.
 	 */
 	public final static int ERROR_MALFORMED_URI = 1007;

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequest.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequest.java
@@ -1,7 +1,9 @@
 package com.thin.downloadmanager;
 
+import android.content.Context;
 import android.net.Uri;
 
+import java.security.InvalidParameterException;
 import java.util.HashMap;
 
 public class DownloadRequest implements Comparable<DownloadRequest> {
@@ -50,11 +52,15 @@ public class DownloadRequest implements Comparable<DownloadRequest> {
 
     private boolean mDeleteDestinationFileOnFailure = true;
 
+    private boolean mWifiOnly = false;
+
     private DownloadRequestQueue mRequestQueue;
 
     private DownloadStatusListener mDownloadListener;
 
     private DownloadStatusListenerV1 mDownloadStatusListenerV1;
+
+    private Context mContext;
 
     private Object mDownloadContext;
 
@@ -145,6 +151,29 @@ public class DownloadRequest implements Comparable<DownloadRequest> {
         this.mDownloadState = mDownloadState;
     }
 
+    public boolean isStateActive() {
+        boolean isActive;
+
+        switch (mDownloadState) {
+            case DownloadManager.STATUS_STARTED:
+            case DownloadManager.STATUS_CONNECTING:
+            case DownloadManager.STATUS_RETRYING:
+            case DownloadManager.STATUS_RUNNING:
+                isActive = true;
+                break;
+            case DownloadManager.STATUS_PENDING:
+            case DownloadManager.STATUS_NOT_FOUND:
+            case DownloadManager.STATUS_SUCCESSFUL:
+            case DownloadManager.STATUS_FAILED:
+                isActive = false;
+                break;
+            default:
+                isActive = false;
+        }
+
+        return isActive;
+    }
+
     DownloadStatusListener getDownloadListener() {
         return mDownloadListener;
     }
@@ -218,6 +247,26 @@ public class DownloadRequest implements Comparable<DownloadRequest> {
     public DownloadRequest setDeleteDestinationFileOnFailure(boolean deleteOnFailure) {
         this.mDeleteDestinationFileOnFailure = deleteOnFailure;
         return this;
+    }
+
+    public boolean isWifiOnly() {
+        return mWifiOnly;
+    }
+
+    /**
+     * Set if file should only be downloaded on WiFi. Use is optional: default is don't care.
+     * @param wifiOnly
+     * @param context Used to get network service.
+     */
+    public DownloadRequest setWifiOnly(boolean wifiOnly, Context context) throws InvalidParameterException {
+        if(wifiOnly && context==null) throw new InvalidParameterException("Context cannot be null");
+        mContext = context.getApplicationContext();
+        mWifiOnly = wifiOnly;
+        return this;
+    }
+
+    public Context getAppContext() {
+        return mContext;
     }
 
     /**

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequestQueue.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadRequestQueue.java
@@ -1,17 +1,25 @@
 package com.thin.downloadmanager;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import java.security.InvalidParameterException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class DownloadRequestQueue {
 
+	private static final String TAG = DownloadRequestQueue.class.getSimpleName();
+	private final boolean DEBUG = false;
 	/**
 	 * The set of all requests currently being processed by this RequestQueue. A Request will be in this set if it is waiting in any queue or currently being processed by any dispatcher.
 	 */
@@ -26,7 +34,11 @@ public class DownloadRequestQueue {
 	/** Used for generating monotonically-increasing sequence numbers for requests. */
 	private AtomicInteger mSequenceGenerator = new AtomicInteger();
 
+	private final AtomicBoolean mWifiBroadcastIsRegistered = new AtomicBoolean(false);
+
 	private CallBackDelivery mDelivery;
+
+	private final WifiStateReceiver mWifiStateReceiver = new WifiStateReceiver();
 
 	/**
 	 * Delivery class to delivery the call back to call back registrar in main thread.
@@ -142,12 +154,14 @@ public class DownloadRequestQueue {
 		request.setDownloadRequestQueue(this);
 
 		synchronized (mCurrentRequests) {
+			if (mCurrentRequests.contains(request)) mCurrentRequests.remove(request); // HashSet doesn't replace "equal" objects
 			mCurrentRequests.add(request);
 		}
 
 		// Process requests in the order they are added.
 		request.setDownloadId(downloadId);
-		mDownloadQueue.add(request);
+
+		startIfRequestedNetworkIsActive(request);
 
 		return downloadId;
 	}
@@ -267,5 +281,213 @@ public class DownloadRequestQueue {
 	 */
 	private int getDownloadId() {
 		return mSequenceGenerator.incrementAndGet();
+	}
+
+	/**
+	 * Try to switch to wifi. Active downloads may interfere
+	 * @return True for wifi is now preferred network
+	 */
+	private boolean attemptSwitchToWifi(Context context) {
+		boolean wifiIsActive = false;
+
+		NetworkHelper networkHelper = NetworkHelper.getInstance(context);
+		// if wifi is the active network
+		if (networkHelper.isActiveNetworkWifi()) {
+			networkHelper.setPreferWifi();
+			wifiIsActive = true;
+			if (DEBUG) Log.d(TAG, "attemptSwitchToWifi() - active network already WiFi.");
+		} else { // another network type is active
+			if (areAllActiveDownloadsWifiOnly()) { // TODO determine if this is an issue
+				if (networkHelper.isWifiAvailable()) {
+					networkHelper.setPreferWifi();
+					wifiIsActive = true;
+					if (DEBUG) Log.d(TAG, "attemptSwitchToWifi() - setting prefer wifi because all wifi-only.");
+				} else {
+					if (DEBUG) Log.d(TAG, "attemptSwitchToWifi() - WiFi is disabled or another non-enabled status.");
+					// WiFi is disabled or another non-enabled status.
+					// It is the responsibility of the app to enable Wifi: We simply handle network change broadcasts.
+				}
+			} else {
+				if (DEBUG) Log.d(TAG, "attemptSwitchToWifi() - Not all active downloads are wifi-only.");
+			}
+		}
+
+		return wifiIsActive;
+	}
+
+	private boolean areAnyDownloadsActive() {
+		boolean dldActive = false;
+
+		for (DownloadRequest downloadRequest : mDownloadQueue) {
+			if (downloadRequest.isStateActive()) {
+				dldActive = true;
+				break;
+			}
+		}
+		return dldActive;
+	}
+
+	/**
+	 * returns true if a download is active that doesn't explicitly request wifi-only
+	 * @return
+	 */
+	private boolean areAllActiveDownloadsWifiOnly() {
+		boolean allWifiOnly = true;
+
+		for (DownloadRequest downloadRequest : mDownloadQueue) {
+			if (!downloadRequest.isWifiOnly()) {
+				if (downloadRequest.isStateActive()) {
+					allWifiOnly = false;
+					break;
+				}
+			}
+		}
+
+		return allWifiOnly;
+	}
+
+	private void registerForWifiConnectedBroadcast(Context context) {
+		// check if already registered
+		synchronized (mWifiBroadcastIsRegistered) {
+			if (!mWifiBroadcastIsRegistered.get()) {
+				IntentFilter intentFilter = new IntentFilter();
+				intentFilter.addAction("android.net.conn.CONNECTIVITY_CHANGE");
+
+				try {
+					context.registerReceiver(mWifiStateReceiver, intentFilter);
+				} catch (IllegalArgumentException e) {
+					// register attempted while already registered
+				}
+
+				mWifiBroadcastIsRegistered.set(true);
+			}
+		}
+	}
+
+	private void unregisterWifiConnectedBroadcast(Context context) {
+		synchronized (mWifiBroadcastIsRegistered) {
+			if (mWifiBroadcastIsRegistered.get()) {
+				try {
+					context.unregisterReceiver(mWifiStateReceiver);
+				} catch (IllegalArgumentException e) {
+					// receiver was not registered
+				}
+
+				mWifiBroadcastIsRegistered.set(false);
+			}
+		}
+	}
+
+	private void tryToStartWifiOnlyDownloads() {
+		// if there are any pending WiFi downloads.
+		if (atLeastOnePendingWifiOnlyDownload()) {
+			// if all active downloads are WiFi-only
+			if (areAllActiveDownloadsWifiOnly()) {
+				// Request prefer wifi
+				NetworkHelper netHelp = NetworkHelper.getInstance();
+				if (netHelp != null) {
+					netHelp.setPreferWifi();
+				}
+
+				if (DEBUG) Log.d(TAG, "tryToStartWifiOnlyDownloads() - all active downloads were wifi-only");
+
+				startAllPendingDownloads();
+			} else { // another network is active
+				if (DEBUG) Log.d(TAG, "tryToStartWifiOnlyDownloads() - a non-wifi-only download was active");
+			}
+		} else {
+			if (!atLeastOneActiveWifiOnlyDownload()) {
+				// reset preferred network
+				NetworkHelper netHelp = NetworkHelper.getInstance();
+				if (netHelp != null) {
+					netHelp.clearNetworkPreference();
+				}
+				if (DEBUG) Log.d(TAG, "tryToStartWifiOnlyDownloads() - there were no active wifi downloads");
+			}
+			if (DEBUG) Log.d(TAG, "tryToStartWifiOnlyDownloads() - there were no pending wifi downloads");
+		}
+	}
+
+	private boolean atLeastOneActiveWifiOnlyDownload() {
+		boolean exists = false;
+
+		for (DownloadRequest request : mDownloadQueue) {
+			if (request.isWifiOnly()) {
+				exists = true;
+				break;
+			}
+		}
+
+		return exists;
+	}
+
+	private void startAllPendingDownloads() {
+		for (DownloadRequest request : mCurrentRequests) {
+			if (request.getDownloadState()==DownloadManager.STATUS_PENDING) {
+				startIfRequestedNetworkIsActive(request);
+			}
+		}
+	}
+
+	private void startIfRequestedNetworkIsActive(DownloadRequest request) {
+		boolean requestedNetworkIsActive = true;
+
+		if (request.isWifiOnly()) {
+			requestedNetworkIsActive = attemptSwitchToWifi(request.getAppContext());
+
+			if (!requestedNetworkIsActive) registerForWifiConnectedBroadcast(request.getAppContext());
+		}
+
+		cancelActiveDownloadWithSameDestinationUri(request);
+
+		if (DEBUG) Log.d(TAG, "startIfRequestedNetworkIsActive() - requestedNetworkIsActive="+requestedNetworkIsActive);
+		if (requestedNetworkIsActive) mDownloadQueue.add(request);
+	}
+
+	private boolean atLeastOnePendingWifiOnlyDownload() {
+		boolean exist = false;
+
+		for (DownloadRequest downloadRequest : mCurrentRequests) {
+			if (downloadRequest.getDownloadState()==DownloadManager.STATUS_PENDING
+					&& downloadRequest.isWifiOnly()) {
+				exist = true;
+				break;
+			}
+		}
+
+		return exist;
+	}
+
+	private boolean cancelActiveDownloadWithSameDestinationUri(DownloadRequest newRequest) {
+		boolean canceledOldDownload = false;
+
+		for (DownloadRequest downloadRequest : mCurrentRequests) {
+			if (downloadRequest.getDownloadId()!=newRequest.getDownloadId() &&
+					downloadRequest.getDestinationURI().getPath().equals(newRequest.getDestinationURI().getPath())) {
+				downloadRequest.cancel();
+				canceledOldDownload = true;
+			}
+		}
+
+		return canceledOldDownload;
+	}
+
+	private class WifiStateReceiver extends BroadcastReceiver {
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			synchronized (mWifiBroadcastIsRegistered) {
+				if (mWifiBroadcastIsRegistered.get()) {
+					if (NetworkHelper.getInstance(context).isWifiAvailable()) {
+						if (DEBUG) Log.d(TAG, "WifiStateReceiver.onReceive() Wifi is Available!");
+						// if there are no non-wifi downloads active, tryToStart
+						tryToStartWifiOnlyDownloads();
+
+						unregisterWifiConnectedBroadcast(context);
+					}
+				} else {
+					unregisterWifiConnectedBroadcast(context);
+				}
+			}
+		}
 	}
 }

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/NetworkHelper.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/NetworkHelper.java
@@ -1,0 +1,161 @@
+package com.thin.downloadmanager;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkInfo;
+import android.net.wifi.WifiManager;
+import android.os.Build;
+import android.util.Log;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Created by bcoien on 3/16/16.
+ */
+public class NetworkHelper {
+    private static final String TAG = NetworkHelper.class.getSimpleName();
+    private final boolean DEBUG = false;
+    private static final String WIFI_LOCK_NAME = "ThinDownloadManager.NetworkHelper";
+    private static NetworkHelper sInstance = null;
+
+    private final int sApiLevel = Build.VERSION.SDK_INT;
+
+    private final Context mContext;
+    private final ConnectivityManager mConManager;
+    private final WifiManager mWifiManager;
+    public static WifiManager.WifiLock sWifiLock = null;
+
+    public static NetworkHelper getInstance(Context context) {
+        if (sInstance == null) sInstance = new NetworkHelper(context.getApplicationContext());
+        return sInstance;
+    }
+
+    /**
+     * Get instance if it has already been constructed
+     * @return May be null
+     */
+    public static NetworkHelper getInstance() {
+        return sInstance;
+    }
+
+    private NetworkHelper(Context context) {
+        if (DEBUG) Log.d(TAG, "NetworkHelper.constructor");
+        mContext = context;
+        mConManager = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        mWifiManager = (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
+        sWifiLock = mWifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL, WIFI_LOCK_NAME);
+        sWifiLock.setReferenceCounted(false);
+        if(sWifiLock.isHeld()) sWifiLock.release();
+    }
+
+    /**
+     * Gets the active network type
+     * @return Of ConnectivityManager.TYPE_[typeName]. Returns -1 for no active network.
+     */
+    private int getActiveNetworkType() {
+        NetworkInfo networkInfo = mConManager.getActiveNetworkInfo();
+        int networkType;
+        if (networkInfo != null && networkInfo.isConnected()) {
+            networkType = networkInfo.getType();
+        } else {
+            networkType = -1; // no active network connection or not connected
+        }
+
+        if (DEBUG) Log.d(TAG, "getActiveNetworkType() - return networkType="+networkType+"; for reference WiFi="+ConnectivityManager.TYPE_WIFI);
+        return networkType;
+    }
+
+    @TargetApi(21) // hush the compiler, we have taken care of it
+    private HttpURLConnection getUrlConnectionOnNetwork(URL url, int networkType) throws IOException  {
+        if (DEBUG) Log.d(TAG,"getUrlConnectionOnNetwork() - enter: url="+url.getPath());
+        HttpURLConnection urlConnection = null;
+
+        if (sApiLevel >= 21) {
+            for(Network network : mConManager.getAllNetworks()) {
+                if(mConManager.getNetworkInfo(network).getType() == networkType) {
+                    urlConnection = (HttpURLConnection) network.openConnection(url);
+                    if (DEBUG) Log.d(TAG, "getUrlConnectionOnNetwork() - found network with matching networkType="+networkType);
+                    break;
+                }
+            }
+        } else {
+            int activeNetworkType = getActiveNetworkType();
+            if (activeNetworkType == networkType) {
+                urlConnection = (HttpURLConnection) url.openConnection();
+                if (DEBUG) Log.d(TAG, "getUrlConnectionOnNetwork() - active network matched networkType="+networkType);
+            } else {
+                if (DEBUG) Log.d(TAG, "getUrlConnectionOnNetwork() - activeNetworkType="+activeNetworkType+" did NOT match desired networkType="+networkType);
+            }
+        }
+
+        String connectionInfoString = urlConnection!=null ? urlConnection.getURL().getPath() : "null";
+        if (DEBUG) Log.d(TAG,"getUrlConnectionOnNetwork() - exit: urlFromConnection="+connectionInfoString);
+        return urlConnection;
+    }
+
+    public HttpURLConnection getUrlConnectionOnWifiNetwork(URL url) throws IOException {
+        return getUrlConnectionOnNetwork(url, ConnectivityManager.TYPE_WIFI);
+    }
+
+    /**
+     * Not required for api>21 because we use getUrlConnectionOnWifiNetwork() to get the UrlConnection directly from the WiFi network
+     */
+    private void setPreferredNetworkType(int networkType) {
+        if (sApiLevel < 21) {
+            mConManager.setNetworkPreference(networkType);
+        }
+    }
+
+    /**
+     * On api <21 sets preferred network type to WiFi.
+     */
+    public void setPreferWifi() {
+        if (DEBUG) Log.d(TAG, "setPreferWifi()");
+        setPreferredNetworkType(ConnectivityManager.TYPE_WIFI);
+
+        if(!sWifiLock.isHeld()) sWifiLock.acquire();
+    }
+
+
+    public boolean isActiveNetworkWifi() {
+        boolean activeNetworkIsWifi = getActiveNetworkType() == ConnectivityManager.TYPE_WIFI;
+        if (DEBUG) Log.d(TAG, "isActiveNetworkWifi() - return="+activeNetworkIsWifi);
+        return activeNetworkIsWifi;
+    }
+
+    public boolean isWifiAvailable() {
+        boolean wifiAvailable = false;
+
+        int wifiState = mWifiManager.getWifiState();
+        if (wifiState == WifiManager.WIFI_STATE_ENABLED) {
+            wifiAvailable = true;
+        }
+
+        if (DEBUG) Log.d(TAG, "isWifiAvailable() - return="+wifiAvailable);
+        return wifiAvailable;
+    }
+
+    /**
+     * On api <21 sets preferred network type.
+     */
+    public void clearNetworkPreference() {
+        if (DEBUG) Log.d(TAG, "clearNetworkPreference()");
+        if (sApiLevel < 21) {
+            mConManager.setNetworkPreference(ConnectivityManager.DEFAULT_NETWORK_PREFERENCE);
+        }
+
+        if(sWifiLock.isHeld()) sWifiLock.release();
+    }
+
+    /**
+     * Get App Context for the download
+     * @return may return null
+     */
+    public Context getAppContext() {
+        return mContext;
+    }
+}

--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/ThinDownloadManager.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/ThinDownloadManager.java
@@ -79,6 +79,9 @@ public class ThinDownloadManager implements DownloadManager {
         if(mRequestQueue != null) {
             mRequestQueue.release();
             mRequestQueue = null;
+            if (NetworkHelper.sWifiLock != null) {
+                NetworkHelper.sWifiLock.release();
+            }
         }
     }
 }

--- a/ThinDownloadManagerTestApp/src/main/AndroidManifest.xml
+++ b/ThinDownloadManagerTestApp/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     package="com.mani.thindownloadmanager.app" >
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:allowBackup="true"

--- a/ThinDownloadManagerTestApp/src/main/java/com/mani/thindownloadmanager/app/MainActivity.java
+++ b/ThinDownloadManagerTestApp/src/main/java/com/mani/thindownloadmanager/app/MainActivity.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
@@ -50,6 +51,9 @@ public class MainActivity extends AppCompatActivity {
     private static final String FILE4 = "https://dl.dropboxusercontent.com/u/25887355/test_video.mp4";
     private static final String FILE5 = "http://httpbin.org/headers";
     private static final String FILE6 = "https://dl.dropboxusercontent.com/u/25887355/ThinDownloadManager.tar.gz";
+
+    private RetryPolicy retryPolicy;
+    private File filesDir;
 
     MyDownloadDownloadStatusListenerV1
         myDownloadStatusListener = new MyDownloadDownloadStatusListenerV1();
@@ -103,92 +107,44 @@ public class MainActivity extends AppCompatActivity {
         mProgress5.setMax(100);
         mProgress5.setProgress(0);
 
+        retryPolicy = new DefaultRetryPolicy();
+        filesDir = getExternalFilesDir("");
+
         downloadManager = new ThinDownloadManager(DOWNLOAD_THREAD_POOL_SIZE);
-        RetryPolicy retryPolicy = new DefaultRetryPolicy();
-
-        File filesDir = getExternalFilesDir("");
-
-        Uri downloadUri = Uri.parse(FILE1);
-        Uri destinationUri = Uri.parse(filesDir+"/test_photo1.JPG");
-        final DownloadRequest downloadRequest1 = new DownloadRequest(downloadUri)
-                .setDestinationURI(destinationUri).setPriority(DownloadRequest.Priority.LOW)
-                .setRetryPolicy(retryPolicy)
-                .setDownloadContext("Download1")
-                .setStatusListener(myDownloadStatusListener);
-
-        downloadUri = Uri.parse(FILE2);
-        destinationUri = Uri.parse(filesDir+"/test_photo2.jpg");
-        final DownloadRequest downloadRequest2 = new DownloadRequest(downloadUri)
-                .setDestinationURI(destinationUri).setPriority(DownloadRequest.Priority.LOW)
-                .setDownloadContext("Download2")
-                .setStatusListener(myDownloadStatusListener);
-
-        downloadUri = Uri.parse(FILE3);
-        destinationUri = Uri.parse(filesDir+"/test_song.mp3");
-        final DownloadRequest downloadRequest3 = new DownloadRequest(downloadUri)
-                .setDestinationURI(destinationUri).setPriority(DownloadRequest.Priority.HIGH)
-                .setDownloadContext("Download3")
-                .setStatusListener(myDownloadStatusListener);
-
-        downloadUri = Uri.parse(FILE4);
-        destinationUri = Uri.parse(filesDir+"/mani/test/aaa/test_video.mp4");
-        // Define a custom retry policy
-        retryPolicy = new DefaultRetryPolicy(5000, 3, 2f);
-        final DownloadRequest downloadRequest4 = new DownloadRequest(downloadUri)
-                .setRetryPolicy(retryPolicy)
-                .setDestinationURI(destinationUri).setPriority(DownloadRequest.Priority.HIGH)
-                .setDownloadContext("Download4")
-                .setStatusListener(myDownloadStatusListener);
-
-        downloadUri = Uri.parse(FILE5);
-        destinationUri = Uri.parse(filesDir+"/headers.json");
-        final DownloadRequest downloadRequest5 = new DownloadRequest(downloadUri)
-                .addCustomHeader("Auth-Token", "myTokenKey")
-                .addCustomHeader("User-Agent", "Thin/Android")
-                .setDestinationURI(destinationUri).setPriority(DownloadRequest.Priority.HIGH)
-                .setDownloadContext("Download5")
-                .setStatusListener(myDownloadStatusListener);
-
-        downloadUri = Uri.parse(FILE6);
-        destinationUri = Uri.parse(filesDir+"/wtfappengine.zip");
-        final DownloadRequest downloadRequest6 = new DownloadRequest(downloadUri)
-                .setDestinationURI(destinationUri).setPriority(DownloadRequest.Priority.HIGH)
-                .setDownloadContext("Download6")
-                .setStatusListener(myDownloadStatusListener);
 
         mDownload1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (downloadManager.query(downloadId1) == DownloadManager.STATUS_NOT_FOUND) {
-                    downloadId1 = downloadManager.add(downloadRequest1);
-                }
+                //if (downloadManager.query(downloadId1) == DownloadManager.STATUS_NOT_FOUND) {
+                    downloadId1 = downloadManager.add(getRequest1());
+                //}
             }
         });
 
         mDownload2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (downloadManager.query(downloadId2) == DownloadManager.STATUS_NOT_FOUND) {
-                    downloadId2 = downloadManager.add(downloadRequest2);
-                }
+                //if (downloadManager.query(downloadId2) == DownloadManager.STATUS_NOT_FOUND) {
+                    downloadId2 = downloadManager.add(getRequest2());
+                //}
             }
         });
 
         mDownload3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (downloadManager.query(downloadId3) == DownloadManager.STATUS_NOT_FOUND) {
-                    downloadId3 = downloadManager.add(downloadRequest3);
-                }
+                //if (downloadManager.query(downloadId3) == DownloadManager.STATUS_NOT_FOUND) {
+                    downloadId3 = downloadManager.add(getRequest3());
+                //}
             }
         });
 
         mDownload4.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (downloadManager.query(downloadId4) == DownloadManager.STATUS_NOT_FOUND) {
-                    downloadId4 = downloadManager.add(downloadRequest4);
-                }
+                //if (downloadManager.query(downloadId4) == DownloadManager.STATUS_NOT_FOUND) {
+                    downloadId4 = downloadManager.add(getRequest4());
+                //}
             }
         });
 
@@ -199,9 +155,9 @@ public class MainActivity extends AppCompatActivity {
                 //    downloadId5 = downloadManager.add(downloadRequest5);
                 //}
 
-              if (downloadManager.query(downloadId6) == DownloadManager.STATUS_NOT_FOUND) {
-                  downloadId6 = downloadManager.add(downloadRequest6);
-              }
+              //if (downloadManager.query(downloadId6) == DownloadManager.STATUS_NOT_FOUND) {
+                  downloadId6 = downloadManager.add(getRequest6());
+              //}
 
           }
         });
@@ -210,11 +166,11 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 downloadManager.cancelAll();
-                downloadId1 = downloadManager.add(downloadRequest1);
-                downloadId2 = downloadManager.add(downloadRequest2);
-                downloadId3 = downloadManager.add(downloadRequest3);
-                downloadId4 = downloadManager.add(downloadRequest4);
-                downloadId5 = downloadManager.add(downloadRequest5);
+                downloadId1 = downloadManager.add(getRequest1());
+                downloadId2 = downloadManager.add(getRequest2());
+                downloadId3 = downloadManager.add(getRequest3());
+                downloadId4 = downloadManager.add(getRequest4());
+                downloadId5 = downloadManager.add(getRequest5());
             }
         });
 
@@ -231,11 +187,60 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        mProgress1Txt.setText("Download1");
+        mProgress1Txt.setText("Download1 - WiFi only");
         mProgress2Txt.setText("Download2");
-        mProgress3Txt.setText("Download3");
+        mProgress3Txt.setText("Download3 - WiFi only");
         mProgress4Txt.setText("Download4");
         mProgress5Txt.setText("Download5");
+    }
+
+    private DownloadRequest getRequest1() {
+        return new DownloadRequest(Uri.parse(FILE1))
+                .setDestinationURI(Uri.parse(filesDir+"/test_photo1.JPG")).setPriority(DownloadRequest.Priority.LOW)
+                .setRetryPolicy(retryPolicy)
+                .setDownloadContext("Download1")
+                .setWifiOnly(true, MainActivity.this.getApplicationContext())
+                .setStatusListener(myDownloadStatusListener);
+    }
+
+    private DownloadRequest getRequest2() {
+        return new DownloadRequest(Uri.parse(FILE2))
+                .setDestinationURI(Uri.parse(filesDir+"/test_photo2.jpg")).setPriority(DownloadRequest.Priority.LOW)
+                .setDownloadContext("Download2")
+                .setWifiOnly(false, this.getApplicationContext())
+                .setStatusListener(myDownloadStatusListener);
+    }
+
+    private DownloadRequest getRequest3() {
+        return new DownloadRequest(Uri.parse(FILE3))
+                .setDestinationURI(Uri.parse(filesDir+"/test_song.mp3")).setPriority(DownloadRequest.Priority.HIGH)
+                .setDownloadContext("Download3")
+                .setWifiOnly(true, this.getApplicationContext())
+                .setStatusListener(myDownloadStatusListener);
+    }
+
+    private DownloadRequest getRequest4() {
+        return new DownloadRequest(Uri.parse(FILE4))
+                .setRetryPolicy(new DefaultRetryPolicy(5000, 3, 2f))
+                .setDestinationURI(Uri.parse(filesDir+"/test_video.mp4")).setPriority(DownloadRequest.Priority.HIGH)
+                .setDownloadContext("Download4")
+                .setStatusListener(myDownloadStatusListener);
+    }
+
+    private DownloadRequest getRequest5() {
+        return new DownloadRequest(Uri.parse(FILE5))
+                .addCustomHeader("Auth-Token", "myTokenKey")
+                .addCustomHeader("User-Agent", "Thin/Android")
+                .setDestinationURI(Uri.parse(filesDir+"/headers.json")).setPriority(DownloadRequest.Priority.HIGH)
+                .setDownloadContext("Download5")
+                .setStatusListener(myDownloadStatusListener);
+    }
+
+    private DownloadRequest getRequest6() {
+        return new DownloadRequest(Uri.parse(FILE6))
+                .setDestinationURI(Uri.parse(filesDir+"/wtfappengine.zip")).setPriority(DownloadRequest.Priority.HIGH)
+                .setDownloadContext("Download6")
+                .setStatusListener(myDownloadStatusListener);
     }
 
     @Override
@@ -274,6 +279,8 @@ public class MainActivity extends AppCompatActivity {
         @Override
         public void onDownloadComplete(DownloadRequest request) {
             final int id = request.getDownloadId();
+
+            System.out.println("######## onDownloadComplete ###### id: "+id);
             if (id == downloadId1) {
                 mProgress1Txt.setText(request.getDownloadContext() + " id: "+id+" Completed");
 
@@ -293,6 +300,8 @@ public class MainActivity extends AppCompatActivity {
         @Override
         public void onDownloadFailed(DownloadRequest request, int errorCode, String errorMessage) {
             final int id = request.getDownloadId();
+
+            System.out.println("######## onDownloadFailed ###### id: "+id+" Failed: ErrorCode "+errorCode+", "+errorMessage);
             if (id == downloadId1) {
                 mProgress1Txt.setText("Download1 id: "+id+" Failed: ErrorCode "+errorCode+", "+errorMessage);
                 mProgress1.setProgress(0);


### PR DESCRIPTION
Implemented WiFi-only downloads:

Behavior:
*If WiFi is unavailable, WiFi-only downloads are queued. 
*When Wifi connects, WiFi-only downloads are started. 
*If WiFi is disabled, it is up to the consuming app or user to enable WiFi. 

Api:
*DownloadRequest has a new method for indicating WiFi only: setWifiOnly(boolean, Context).  
*This method includes a context to maintain full api backward compatibility.  
*Using this requires additional permissions: see permissions section in README. No additional permissions are required until after a WiFi-only DownloadRequest has been added. 

Fix:
*When a new download is added to the queue, cancel active downloads with the same destination file.

TestApp: 
*Dynamically created requests: serves to reset DownloadRequest status on repeated requests. 
*Added newly required permissions for WiFi only.

Thank you for your time and consideration.