### PR TITLE
Support the Partial Download Response. 

### DIFF
--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
@@ -23,6 +23,7 @@ import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_PARTIAL;
 import static java.net.HttpURLConnection.HTTP_SEE_OTHER;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 
@@ -136,6 +137,7 @@ public class DownloadDispatcher extends Thread {
                 + responseCode);
             
             switch (responseCode) {
+                case HTTP_PARTIAL:
                 case HTTP_OK:
                     shouldAllowRedirects = false;
                     if (readResponseHeaders(conn) == 1) {


### PR DESCRIPTION
The Partial Download HTTP response code is in response to a request which includes the Range header field. 

Handling this as a normal download enables resuming incomplete downloads.

To use this for resuming downloads, do something similar to the below sudocode.

---Create Resumable Download Request---
```
Use the DownloadRequest setters::
    setDeleteDestinationFileOnFailure(isResumable)
    setDownloadContext(yourDownloadInfoWhichIncludesYourCallbackAndIsResumableBool)

If resumable
   if part1 file exists {
        downloadRequest.setDestinationURI(destinationURI+PART2_POSTFIX);
        downloadRequest.addCustomHeader("Range", "bytes="+part1.length()+"-"); //header magic
   }  else
        downloadRequest.setDestinationURI(destinationURI+PART1_POSTFIX);
else
   downloadRequest.setDestinationURI(destinationURI);
```
------

---In FinishedDownloadHandler: started by DownloadStatusListenerV1.onDownloadComplete() callback: don't run on mainLooper!--
```
YourDownloadInfo yourDownloadInfo = (YourDownloadInfo) downloadRequest.getDownloadContext();

String tempPath = downloadRequest.getDestinationURI().toString();
if (yourDownloadInfo!=null && yourDownloadInfo.isResumable()) {
    String tempPathPart2 = tempPath+PART2_POSTFIX;

    File firstPart = null;
    File secondPart = null;
    try {
        firstPart = new File(new URI(tempPath));
        secondPart = new File(new URI(tempPathPart2));
    } catch (URISyntaxException e) {
        e.printStackTrace();
    }

    if(firstPart!=null && firstPart.exists() && secondPart !=null && secondPart.exists()){
        concatSecondOntoFirstAndDeleteSecond(firstPart, secondPart);
    } else {
        yourDownloadInfo.getYourCallback.onDownloadFailed(yourDownloadInfo);
    }
    firstPart.rename(new File(tempPath.substring(0, tempPath.length()-PART1_POSTFIX.length())));
}

yourDownloadInfo.getYourCallback.onDownloadFinished(yourDownloadInfo);
```
---