### PR TITLE
Fixed failure in writing file flow. When some error occurs during wri…

### DIFF
--- a/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
+++ b/ThinDownloadManager/src/main/java/com/thin/downloadmanager/DownloadDispatcher.java
@@ -2,6 +2,9 @@ package com.thin.downloadmanager;
 
 import android.os.Process;
 import android.util.Log;
+
+import org.apache.http.conn.ConnectTimeoutException;
+
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
@@ -17,7 +20,6 @@ import java.util.HashMap;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.BlockingQueue;
-import org.apache.http.conn.ConnectTimeoutException;
 
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
@@ -303,6 +305,10 @@ public class DownloadDispatcher extends Thread {
 
             if (writeDataToDestination(data, bytesRead, out)) {
                 mCurrentBytes += bytesRead;
+            }else {
+                mRequest.finish();
+                updateDownloadFailed(DownloadManager.ERROR_FILE_ERROR, "Failed writing file");
+                return;
             }
         }
     }


### PR DESCRIPTION
Fixed failure in writing file flow.

When an error occurs in writeDataToDestination the download process does not stop. It is a problem because transferData method continues reading bytes from inputstream and at the end we get a corrupted file.

The approach was finish the download process with failed status when some error occurs in writeDataToDestination method.